### PR TITLE
Fix Streamlit auto refresh

### DIFF
--- a/mood.py
+++ b/mood.py
@@ -53,7 +53,13 @@ def plot_mood_chart(df, date, title):
         st.info(f"No moods logged on {date}.")
 
 st.set_page_config(page_title="Mood Tracker", page_icon="🧠", layout="centered")
-st.experimental_rerun_interval = 30
+# Automatically refresh the dashboard every 30 seconds
+try:
+    from streamlit_autorefresh import st_autorefresh
+    st_autorefresh(interval=30 * 1000, key="auto_refresh")
+except Exception:
+    # If the autorefresh helper isn't available, continue without it
+    pass
 st.title("🧠 Mood of the Queue")
 
 st.subheader("Log a Mood")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas>=1.3
 plotly>=5.5
 gspread>=5.7
 oauth2client>=4.1.3
+streamlit-autorefresh>=0.0.3


### PR DESCRIPTION
## Summary
- fix bug where non-existent `st.experimental_rerun_interval` attribute was referenced
- use optional `streamlit_autorefresh` helper for auto refresh
- add dependency for `streamlit-autorefresh`

## Testing
- `python -m py_compile mood.py`


------
https://chatgpt.com/codex/tasks/task_e_685095f33eb48325af1a6720fcea7a71